### PR TITLE
Remove redundant ESLint ignore and globals lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,21 +22,12 @@
   },
   "eslintConfig": {
     "extends": "@playcanvas/eslint-config",
-    "globals": {
-      "pc": "readonly",
-      "spine": "readonly",
-      "semver": "readonly"
-    },
     "settings": {
       "import/core-modules": [
         "spine-core-import"
       ]
     }
   },
-  "eslintIgnore": [
-    "build/",
-    "contrib/"
-  ],
   "devDependencies": {
     "@babel/preset-env": "^7.22.10",
     "@playcanvas/eslint-config": "^1.7.0",


### PR DESCRIPTION
With the move to ES Modules, we no longer need the ESLint ignore list and globals list.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
