### PR TITLE
Do not disable any ESLint rules

### DIFF
--- a/src/SpinePlugin.js
+++ b/src/SpinePlugin.js
@@ -12,17 +12,9 @@ import { SpineComponentSystem } from './component/SpineComponentSystem.js';
 
 // register the plugin with playcanvas
 (function () {
-    if (pc.Application.registerPlugin) {
-        var register = function (app) {
-            // eslint-disable-next-line no-new
-            new SpineComponentSystem(app);
-        };
-        pc.Application.registerPlugin("spine", register);
-    } else {
-        var app = pc.Application.getApplication();
-        var system = new SpineComponentSystem(app);
-        app.systems.add(system);
-    }
+    const app = pc.Application.getApplication();
+    const system = new SpineComponentSystem(app);
+    app.systems.add(system);
 }());
 
 // we export spine for compatibility and to allow developers

--- a/src/component/Spine.js
+++ b/src/component/Spine.js
@@ -1,4 +1,3 @@
-/* eslint-disable operator-linebreak */
 import * as pc from 'playcanvas';
 import { spine } from 'spine-core-import'; // spine-core-import is an alias
 import { SpineTextureWrapper } from './SpineTextureWrapper.js';
@@ -280,11 +279,11 @@ class Spine {
         // attachment can change on the slot
         // prettier-ignore
         const type =
-            attachment instanceof spine.RegionAttachment
-                ? ATTACHMENT_TYPE.REGION
-                : attachment instanceof spine.MeshAttachment
-                    ? ATTACHMENT_TYPE.MESH
-                    : ATTACHMENT_TYPE.NULL;
+            attachment instanceof spine.RegionAttachment ?
+                ATTACHMENT_TYPE.REGION :
+                attachment instanceof spine.MeshAttachment ?
+                    ATTACHMENT_TYPE.MESH :
+                    ATTACHMENT_TYPE.NULL;
 
         if (slot._active.name !== name || slot._active.type !== type) {
             this.initAttachment(slot);

--- a/src/component/SpineComponent.js
+++ b/src/component/SpineComponent.js
@@ -1,4 +1,3 @@
-/* eslint-disable operator-linebreak */
 import { Asset, Component, path as resourcePath } from 'playcanvas';
 
 import { Spine } from './Spine.js';
@@ -26,11 +25,11 @@ class SpineComponent extends Component {
         for (let i = 0, n = this.textureAssets.length; i < n; i++) {
             const asset = this.system.app.assets.get(this.textureAssets[i]);
 
-            let path = asset.name
-                ? asset.name
-                : asset.file
-                    ? asset.file.filename
-                    : null;
+            let path = asset.name ?
+                asset.name :
+                asset.file ?
+                    asset.file.filename :
+                    null;
 
             // Fallback if filename doesn't exist
             if (!path) {


### PR DESCRIPTION
This PR removes 3 instances where ESLint rules are disabled.

Note that `Application#registerPlugin` has not been in the Engine API for many years. Noone developing with this plugin today will still be on such an old engine.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
