### PR TITLE
chore: mark webp images as binary for repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,7 @@
 *.babelrc text
 
 # Denote all files that are truly binary and should therefore not be modified.
+*.webp binary
 *.png binary
 *.jpg binary
 *.glb binary


### PR DESCRIPTION
Ensure webp images are binary in future examples.

Fixes none.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
